### PR TITLE
feat: Add offline cache support for bus schedule data

### DIFF
--- a/Tests/SFCBusScheduleTests/SFCBusScheduleTests.swift
+++ b/Tests/SFCBusScheduleTests/SFCBusScheduleTests.swift
@@ -87,4 +87,45 @@ final class SFCBusScheduleTests {
         let url = SFCBusScheduleAPI.makeURL(direction: .fromSFC, day: .weekday)
         #expect(url?.absoluteString == "https://sugijotaro.github.io/sfc-bus-schedule/data/v1/flat/from_sfc_weekday.json")
     }
+
+    @Test func testCacheKeyGeneration() {
+        let key1 = SFCBusScheduleAPI.cacheKey(direction: .fromSFC, day: .weekday)
+        let key2 = SFCBusScheduleAPI.cacheKey(direction: .toSFC, day: .saturday)
+        
+        #expect(key1 == "sfc_bus_schedule_cache_from_sfc_weekday")
+        #expect(key2 == "sfc_bus_schedule_cache_to_sfc_saturday")
+        #expect(key1 != key2)
+    }
+
+    @Test func testCacheSaveAndLoad() async throws {
+        let testSchedules = try JSONDecoder().decode([BusSchedule].self, from: mockBusScheduleJSON)
+        
+        SFCBusScheduleAPI.saveToCache(testSchedules, direction: .toSFC, day: .weekday)
+        
+        let cachedSchedules = SFCBusScheduleAPI.loadFromCache(direction: .toSFC, day: .weekday)
+        
+        #expect(cachedSchedules != nil)
+        #expect(cachedSchedules?.count == 1)
+        #expect(cachedSchedules?[0].id == "sho250710")
+        #expect(cachedSchedules?[0].routeCode == .sho25)
+        #expect(cachedSchedules?[0].scheduleType == .weekday)
+    }
+
+    @Test func testCacheNotFound() {
+        let nonExistentCache = SFCBusScheduleAPI.loadFromCache(direction: .fromSFC, day: .saturday)
+        #expect(nonExistentCache == nil)
+    }
+
+    @Test func testBusScheduleResponse() {
+        let schedules = try? JSONDecoder().decode([BusSchedule].self, from: mockBusScheduleJSON)
+        #expect(schedules != nil)
+        
+        let liveResponse = BusScheduleResponse(schedules: schedules!, source: .live)
+        let cacheResponse = BusScheduleResponse(schedules: schedules!, source: .cache)
+        
+        #expect(liveResponse.schedules.count == 1)
+        #expect(cacheResponse.schedules.count == 1)
+        #expect(liveResponse.source == .live)
+        #expect(cacheResponse.source == .cache)
+    }
 }


### PR DESCRIPTION
## 変更内容
- バススケジュールデータのオフライン対応としてキャッシュ機能を追加
- ネットワーク接続がない場合、過去に保存したデータをキャッシュとして使用
- データの取得元（live/cache）を区別可能に

## 技術的な変更点
- `BusScheduleResponse` 構造体の追加（データと取得元を含む）
- `DataSource` 列挙型の追加（`.live` または `.cache`）
- キャッシュ関連のメソッド実装
  - `cacheKey`: キャッシュキーの生成
  - `saveToCache`: データのキャッシュ保存
  - `loadFromCache`: キャッシュからのデータ取得

## 使用方法
```swift
do {
    let response = try await SFCBusScheduleAPI.fetchSchedule(direction: .fromSFC, day: .weekday)
    switch response.source {
    case .live:
        print("最新のデータを取得しました")
    case .cache:
        print("キャッシュされたデータを使用しています")
    }
    let schedules = response.schedules
    // スケジュールデータの使用
} catch {
    // エラー処理
}
```

## テスト
- キャッシュキーの生成テスト
- キャッシュの保存・取得テスト
- キャッシュが見つからない場合のテスト
- レスポンス構造のテスト

## 注意点
- 通常時は常に最新のデータを取得
- オフライン時のみキャッシュを使用
- キャッシュは成功時に自動更新