### PR TITLE
feat: Use URLSession cachePolicy to distinguish live and cache data for bus schedule API

### DIFF
--- a/Sources/SFCBusSchedule/BusScheduleModels.swift
+++ b/Sources/SFCBusSchedule/BusScheduleModels.swift
@@ -152,4 +152,4 @@ public struct Arrival: Codable {
         self.time = time
         self.minute = minute
     }
-} 
+}

--- a/Sources/SFCBusSchedule/SFCBusSchedule.swift
+++ b/Sources/SFCBusSchedule/SFCBusSchedule.swift
@@ -60,8 +60,11 @@ public struct SFCBusScheduleAPI {
             throw BusScheduleError.invalidURL
         }
 
+        var request = URLRequest(url: url)
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+
         do {
-            let (data, _) = try await URLSession.shared.data(from: url)
+            let (data, response) = try await URLSession.shared.data(for: request)
             let schedules = try JSONDecoder().decode([BusSchedule].self, from: data)
             saveToCache(schedules, direction: direction, day: day)
             return BusScheduleResponse(schedules: schedules, source: .live)


### PR DESCRIPTION
## 変更内容
- バススケジュールAPIでURLSessionのcachePolicyを利用し、UserDefaultsキャッシュとHTTPキャッシュの区別を明確化
- オフライン時はUserDefaultsキャッシュを返却し、通常時は常にネットワークから取得を試みるように修正
- 取得元（live/cache）の判定精度を向上

## 技術的なポイント
- URLRequestのcachePolicyに.reloadIgnoringLocalCacheDataを指定
- これにより、iOSのHTTPキャッシュ経由のデータ取得時もcatch節に入りやすくなり、UserDefaultsキャッシュとの区別が明確に

## 注意点
- サーバーやネットワーク環境によっては完全なライブ判定が難しい場合もあるため、ドキュメント等で注意喚起を推奨